### PR TITLE
Add ability to apply headless UI settings via GRAPHICS_FRONT_END variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# root registry url
+REGISTRY_URL="olgit.orbitlogic.com:5050/aps/aps-deploy"

--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# root registry url
-REGISTRY_URL="olgit.orbitlogic.com:5050/aps/aps-deploy"

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Docker-compose environment vars
 
+# Supply the registry URL to your 42 image:
+REGISTRY_URL=""
+
 # It is recommended to use the following in your host environment:
 # export DISPLAY=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf 2>/dev/null):0
 # However, the following can be used as override:

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY Makefile $INSTALL
 WORKDIR $INSTALL
 RUN make
 
+#=====================================================
 # Copy built 42 artifacts to base container
 FROM base
 
@@ -88,11 +89,23 @@ COPY --from=build [ \
     "${LIB_INSTALL}" \
 ]
 
-# Environment and execution
+# Docker entrypoint script and hooks
 COPY docker-entrypoint.sh /
+RUN mkdir -p /docker-entrypoint.d
+
+COPY docker-entrypoint.d /
 RUN chmod 755 /docker-entrypoint.sh
+
+# Default scenarios location
+RUN mkdir -p /42/scenarios
+RUN chmod -R 666 /42/scenarios
+ENV FORTYTWO_SCENARIO=scenarios/default
+# Note that the scenarios directory must be relative to the 42 root!
+
+# Environment setup
 ENV LD_LIBRARY_PATH="${INSTALL}/lib:${LD_LIBRARY_PATH}"
-ENV FORTYTWO_SCENARIO=""
+ENV LIBGL_ALWAYS_INDIRECT=0
+
 WORKDIR /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   app:
-    image: proget.orbitlogic.com:81/ol-docker/aps/42:latest
+    image: ${REGISTRY_URL}/42:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-entrypoint.d/Readme.md
+++ b/docker-entrypoint.d/Readme.md
@@ -1,0 +1,1 @@
+Any executable shell scripts (*.sh) in this location will be executed at startup.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,27 @@
 #!/bin/bash
 set -x
+# By default, scenarios are stored under /42/scenarios
+# When invoked below, 42 takes as argument a scenario directory relative to its root, e.g.
+# ./42 my_scenarios
 
-if [[ ! -d "$FORTYTWO_SCENARIO" ]]; then 
+if [[ ! -d "$FORTYTWO_SCENARIO" ]]; then
     echo "$0: No FORTYTWO_SCENARIO provided. Using defaults."
 else
     echo "$0: Running with scenario $FORTYTWO_SCENARIO"
 fi
 
+# Controls for headless mode
+if [[ "$GRAPHICS_FRONT_END" == "false" ]]; then
+    echo "$0: Setting graphics front end to FALSE (no x-windows)"
+    sed -i 's/TRUE\(.*Graphics Front End?\)/FALSE\1\*\*/' /42/$FORTYTWO_SCENARIO/Inp_Sim.txt > /dev/null 2>&1
+fi
+
+# Allow for initial user script execution
+DIR=/docker-entrypoint.d
+if [[ -d "$DIR" ]]; then
+  /bin/run-parts --verbose "$DIR"
+fi
+
+# Execute
 cd /42 && ./42 $FORTYTWO_SCENARIO 2>&1
 exec "$@"


### PR DESCRIPTION
This update applies to docker execution only. When setting GRAPHICS_FRONT_END="true" in the docker runtime (via environment variable), the docker entry point script makes an inline text change: Graphics Front End? => FALSE to the Inp_Sim.txt file. A better change would avoid permanently changing the Inp_Sim.txt file, which currently needs to be reverted manually. 

Other changes:
- Add support for running any shell script placed in /docker-entrypoint.d (via run-parts)
- Better logic for setting FORTYTWO_SCENARIO and default scenario location
- Add docker-compose .env file and URL example