### PR TITLE
fix: Fixing apt-get installs for Docker image

### DIFF
--- a/OrbitLogic/.env.example
+++ b/OrbitLogic/.env.example
@@ -1,7 +1,7 @@
 # Docker-compose environment vars
 
 # Supply the registry URL to your 42 image:
-REGISTRY_URL=cogit-art.orbitlogic.com:5050/aps/store
+REGISTRY_URL=collab-nexus.hq.orbitlogic.com:5000/aps/simulators
 
 # It is recommended to use the following in your host environment:
 # export DISPLAY=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf 2>/dev/null):0

--- a/OrbitLogic/Dockerfile
+++ b/OrbitLogic/Dockerfile
@@ -7,8 +7,8 @@ FROM base as build
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt-get install -y \
-    vim-gtk \
+RUN apt-get update && apt-get install -y \
+    vim-gtk3 \
     gcc \
     g++ \
     freeglut3-dev \
@@ -73,7 +73,7 @@ FROM base
 RUN apt update && apt-get install -y \
     net-tools \
     tcpdump \
-    netcat \
+    netcat-traditional \
 && rm -rf /var/lib/apt/lists/*
 
 ARG INSTALL="/42"

--- a/OrbitLogic/Dockerfile
+++ b/OrbitLogic/Dockerfile
@@ -70,7 +70,7 @@ RUN make
 FROM base
 
 # Install select tools we want in the final image
-RUN apt update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     net-tools \
     tcpdump \
     netcat-traditional \


### PR DESCRIPTION
I don't know why these packages were no longer working but these changes allowed me to build the Docker image successfully 